### PR TITLE
Get format and styles from the WMTS GetCapabilities document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.egg-info
+wmtsproxy/build
+wmtsproxy/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:2
+
+RUN apt-get update
+RUN apt-get install -y proj-bin python-pip libapr1 libapr1-dev libaprutil1-dev \
+  python-dev python-setuptools \
+  libffi-dev libxml2-dev libxslt1-dev \
+  libtiff-dev libjpeg62-turbo-dev zlib1g-dev libfreetype6-dev \
+  liblcms2-dev libwebp-dev python-tk
+
+# RUN pip install meinheld gunicorn
+ENV PROXY_PORT=5000
+
+RUN python -m pip install --upgrade pip
+
+WORKDIR /usr/src/app
+
+COPY wmtsproxy ./wmtsproxy
+COPY wmtsproxy_restapi ./wmtsproxy_restapi
+
+RUN cd wmtsproxy/ && \
+  pip install --no-cache-dir -r requirements.txt && \
+  python setup.py install
+
+RUN cd wmtsproxy_restapi/ && \
+  pip install --no-cache-dir -r requirements.txt && \
+  python setup.py install
+
+# COPY services.csv .
+COPY deploy.py .
+
+CMD ["python", "deploy.py"]

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,19 @@
+import os
+import logging
+
+from wmtsproxy_restapi.app import create_app
+
+app = create_app()
+
+logging_handler = logging.StreamHandler()
+logging_handler.setLevel(logging.DEBUG)
+app.logger.addHandler(logging_handler)
+
+port = os.environ.get('PROXY_PORT')
+if port is None:
+  port = 9091
+else:
+  port = int(port)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', threaded=True, port=port)

--- a/wmtsproxy/requirements.txt
+++ b/wmtsproxy/requirements.txt
@@ -1,4 +1,4 @@
 Pillow==2.3.1
 PyYAML==3.11
 requests==2.2.1
-MapProxy>=1.7.0a-20140411
+MapProxy==1.7.0

--- a/wmtsproxy/setup.py
+++ b/wmtsproxy/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='wmtsproxy',
-      version='0.1.2',
+      version='0.2.0',
       description='WMTSProxy makes WMS/WMTS layers available as WMTS',
       author='Omniscale GmbH & Co. KG',
       author_email='support@omniscale.de',

--- a/wmtsproxy/setup.py
+++ b/wmtsproxy/setup.py
@@ -12,6 +12,6 @@ setup(name='wmtsproxy',
       install_requires=[
         "PyYAML",
         "requests",
-        "mapproxy>=1.7.0",
+        "mapproxy==1.7.0",
       ]
 )

--- a/wmtsproxy/wmtsproxy/capabilities.py
+++ b/wmtsproxy/wmtsproxy/capabilities.py
@@ -72,6 +72,8 @@ def wmts_cap_dict(cap):
             'title': layer['title'],
             'matrix_sets': [matrix_set['id'] for matrix_set in layer['matrix_sets']],
             'llbbox': layer['bbox'],
+            'formats': layer['formats'],
+            'styles': layer['styles']
         })
         dimension = wmts_layer_dimensions(layer)
         if dimension:


### PR DESCRIPTION
Our [wms-mapproxy](https://github.com/CartoDB/cartodb-wmsproxy) has an API in order to get the URL templates and the parameters value for a WMTS GetCapabilities document. Example:

https://cartodb-wms.global.ssl.fastly.net/api/check?url=https%3A%2F%2Fwww.ign.es%2Fwmts%2Fign-base%3F%26request%3DGetCapabilities%26service%3DWMS&type=wms

```json
{
  "layers": [
    {
      "llbbox": [-19, 27, 5, 44],
      "matrix_sets": ["GoogleMapsCompatible"],
      "name": "IGNBaseTodo-nofondo",
      "title": "Callejero recortado",
      "url_template": "https://www.ign.es/wmts/ign-base?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=%(layer)s&TILEMATRIXSET=%(tile_matrix_set)s&TILEMATRIX=%%(z)s&TILEROW=%%(y)s&TILECOL=%%(x)s&FORMAT=%(format)s"
    },
    {
      "llbbox": [-30, 26, 25, 55],
      "matrix_sets": [
        "InspireCRS84Quad",
        "EPSG:4326",
        "EPSG:4258",
        "EPSG:25830",
        "GoogleMapsCompatible"
      ],
      "name": "IGNBaseTodo",
      "title": "Callejero",
      "url_template": "https://www.ign.es/wmts/ign-base?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=%(layer)s&TILEMATRIXSET=%(tile_matrix_set)s&TILEMATRIX=%%(z)s&TILEROW=%%(y)s&TILECOL=%%(x)s&FORMAT=%(format)s"
    },
    {
      "llbbox": [-30, 26, 25, 55],
      "matrix_sets": ["GoogleMapsCompatible"],
      "name": "IGNBase-gris",
      "title": "Callejero gris",
      "url_template": "https://www.ign.es/wmts/ign-base?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=%(layer)s&TILEMATRIXSET=%(tile_matrix_set)s&TILEMATRIX=%%(z)s&TILEROW=%%(y)s&TILECOL=%%(x)s&FORMAT=%(format)s"
    },
    {
      "llbbox": [-30, 26, 25, 55],
      "matrix_sets": [
        "GoogleMapsCompatible",
        "InspireCRS84Quad",
        "EPSG:4326",
        "EPSG:4258",
        "EPSG:25830"
      ],
      "name": "IGNBaseOrto",
      "title": "Callejero para imagen",
      "url_template": "https://www.ign.es/wmts/ign-base?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=%(layer)s&TILEMATRIXSET=%(tile_matrix_set)s&TILEMATRIX=%%(z)s&TILEROW=%%(y)s&TILECOL=%%(x)s&FORMAT=%(format)s"
    }
  ],
  "title": "Mapa Base de España",
  "type": "wmts"
}
```

This API is returning the `matrix_sets`, `name`  values but it is not getting the `format` and the `style` values from the GetCapabilities document needed to replace the url template and mandatory by the WMTS OGC standard.

This PR gets the `format` and `style` values from a GetCapabilities document. With the previous example:

```json
{
  "layers": [
    {
      "formats": ["image/png"],
      "llbbox": [-19, 27, 5, 44],
      "matrix_sets": ["GoogleMapsCompatible"],
      "name": "IGNBaseTodo-nofondo",
      "styles": [],
      "title": "Callejero recortado"
    },
    {
      "formats": ["image/jpeg", "image/png"],
      "llbbox": [-30, 26, 25, 55],
      "matrix_sets": [
        "InspireCRS84Quad",
        "EPSG:4326",
        "EPSG:4258",
        "EPSG:25830",
        "GoogleMapsCompatible"
      ],
      "name": "IGNBaseTodo",
      "styles": [
        {
          "default": true,
          "id": "default",
          "title": "Estilo de representación del Mapa base"
        }
      ],
      "title": "Callejero"
    },
    {
      "formats": ["image/jpeg"],
      "llbbox": [-30, 26, 25, 55],
      "matrix_sets": ["GoogleMapsCompatible"],
      "name": "IGNBase-gris",
      "styles": [
        {
          "default": true,
          "id": "default",
          "title": "Estilo de representación del Mapa base en gris"
        }
      ],
      "title": "Callejero gris"
    },
    {
      "formats": ["image/png"],
      "llbbox": [-30, 26, 25, 55],
      "matrix_sets": [
        "GoogleMapsCompatible",
        "InspireCRS84Quad",
        "EPSG:4326",
        "EPSG:4258",
        "EPSG:25830"
      ],
      "name": "IGNBaseOrto",
      "styles": [
        {
          "default": true,
          "id": "default",
          "title": "IGN: Estilo de Mapa Base para ortoimagen"
        }
      ],
      "title": "Callejero para imagen"
    }
  ],
  "title": "Mapa Base de España",
  "type": "wmts"
}
```

In addition, dockerize the project in order to make easier deploy and dev in local.